### PR TITLE
Move settings tab initialization to `init` hook to comply with WP 6.7 i18n timing

### DIFF
--- a/admin/class-nginx-helper-admin.php
+++ b/admin/class-nginx-helper-admin.php
@@ -74,10 +74,20 @@ class Nginx_Helper_Admin {
 	 * @param      string $version    The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
+	    $this->plugin_name = $plugin_name;
+	    $this->version     = $version;
 
-		$this->plugin_name = $plugin_name;
-		$this->version     = $version;
+	    // Initialize options early.
+	    $this->options = $this->nginx_helper_settings();
+	}
 
+
+	/**
+	 * Initialize the settings tab.
+	 * Required since i18n is used in the settings tab which can be invoked only after init hook since WordPress 6.7
+	 */
+	public function initialize_setting_tab() {
+		
 		/**
 		 * Define settings tabs
 		 */
@@ -94,10 +104,8 @@ class Nginx_Helper_Admin {
 				),
 			)
 		);
-
-		$this->options = $this->nginx_helper_settings();
-
 	}
+
 
 	/**
 	 * Register the stylesheets for the admin area.

--- a/includes/class-nginx-helper.php
+++ b/includes/class-nginx-helper.php
@@ -170,6 +170,10 @@ class Nginx_Helper {
 
 		$nginx_helper_admin = new Nginx_Helper_Admin( $this->get_plugin_name(), $this->get_version() );
 
+		# New Line to fix tex domain issues as we've moved the setting tab
+	    $this->loader->add_action( 'init', $nginx_helper_admin, 'initialize_setting_tab' );
+
+
 		// Defines global variables.
 		if ( ! empty( $nginx_helper_admin->options['cache_method'] ) && 'enable_redis' === $nginx_helper_admin->options['cache_method'] ) {
 


### PR DESCRIPTION
**Summary**
This change moves the Nginx Helper settings tab initialization out of the class constructor and into a new `initialize_setting_tab()` method, which is now called on the `init` hook. This aligns with the recommended pattern introduced in WordPress 6.7, ensuring that any UI using translation functions (`__()`, `_e()`, etc.) is registered after text domains are fully loaded.

**What Changed**
- Moved `$this->options = $this->nginx_helper_settings();` to the top of the constructor and closed it early.
- Extracted all settings tab registration code into a new `initialize_setting_tab()` method.
- Hooked `initialize_setting_tab()` on the `init` action in `define_admin_hooks()`.
- Removed the old settings-tab code from the constructor.

**Why**
- Prevents the `_load_textdomain_just_in_time` notice introduced in WP 6.7 when translations are used before the `init` hook.
- Makes the settings tab initialization cleaner and more consistent with WordPress loading order best practices.

**References**
- Original upstream PR: [rtCamp/nginx-helper#365](https://github.com/rtCamp/nginx-helper/pull/365)
- WordPress 6.7 i18n change reference: https://make.wordpress.org/core/2024/09/23/textdomain-loading-changes-in-wordpress-6-7/

**Testing**
- Verified settings tab loads correctly after init.
- Confirmed no i18n notices are thrown on plugin activation or settings page load.
- Backward compatibility preserved — no changes to UI or stored options.

** Can be confirmed fixing using Query Monitor **
https://app.usebubbles.com/sdAwmhMYDW2tyX7pPzpf4j/pr-ngnix-helper-gridpane
